### PR TITLE
Fixes script path on loadlwf-sample

### DIFF
--- a/html5/lwf-loader/loadlwf-sample.html
+++ b/html5/lwf-loader/loadlwf-sample.html
@@ -8,8 +8,7 @@
   <link rel="stylesheet" type="text/css" href="css/sample.css">
   <script type="text/javascript" src="js/lwf.js"></script>
   <script type="text/javascript" src="js/underscore-min.js"></script>
-  <script type="text/javascript" src="lwf-loader/js/lwf-util.js"></script>
-  <script type="text/javascript" src="lwf-loader/js/lwf-loader.js"></script>
+  <script type="text/javascript" src="js/lwf-loader.min.js"></script>
 
   <script type="text/javascript">
     var setting = {


### PR DESCRIPTION
Fixes script path on `loadlwf-sample.html`. That's no problem about remove lwf-util by https://github.com/gree/lwf-loader/commit/86bcb7eba6edd91c4c34aeebb15b0d17af011067

current version: http://gree.github.io/lwf-demo/html5/lwf-loader/loadlwf-sample.html
my fixed: http://watilde.github.io/lwf-demo/html5/lwf-loader/loadlwf-sample.html
